### PR TITLE
Fixes for shows with simple title

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.pogdesign.sync"
        name="pogdesign-sync"
-       version="0.1.3"
+       version="0.1.4"
        provider-name="rafakob">
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>

--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.pogdesign.sync"
        name="pogdesign-sync"
-       version="0.1.2"
+       version="0.1.3"
        provider-name="rafakob">
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>

--- a/cal.py
+++ b/cal.py
@@ -48,8 +48,12 @@ class Calendar():
         if content is None:
           return None
 
-        eps = re.findall('class="watchcheck" type="checkbox" value="(.*)" />', content)
-        return next((x for x in eps if x.find('-' + str(season) + '-' + str(episode) + '/') != -1), None)
+        matcher = re.compile('class="watchcheck" type="checkbox" value="(\d*-[0]*' + str(season) + '-[0]*' + str(episode) + '/\d*-\d*)')
+        epid = matcher.findall(content)
+        if not epid:
+            return None
+        else:
+            return epid[0]
 
     """ Processing Kodi's show name into Pogdesign name used in URL of -summary page (eg. "Mr. Robot" to "Mr-Robot") """
     def process_name(self, show, remove_brackets = False):

--- a/cal.py
+++ b/cal.py
@@ -34,17 +34,16 @@ class Calendar():
     def get_epid(self,show,season,episode):
         showName = show
         content = ""
-        if showName != self.process_name(show):
+        try:
+          showName = self.process_name(show)
+          content = self.get_page(self.baseURL + '/cat/' + showName + '-summary')
+        except:
           try:
-            showName = self.process_name(show)
+            showName = self.process_name(show, True)
             content = self.get_page(self.baseURL + '/cat/' + showName + '-summary')
           except:
-            try:
-              showName = self.process_name(show, True)
-              content = self.get_page(self.baseURL + '/cat/' + showName + '-summary')
-            except:
-              content = None
-              return None
+            content = None
+            return None
 
         if content is None:
           return None

--- a/service.py
+++ b/service.py
@@ -83,7 +83,9 @@ class Main:
                 log('Library has been changed. Performing full sync.....')
                 try:
                     for el in self.eps_watched:
+                        log('Getting epid for Show: {0} Season: {1} Episode: {2}'.format(el[0], el[1], el[2]))
                         epid = calendar.get_epid(el[0], el[1], el[2])
+                        log('Epid: {0}'.format(epid))
                         calendar.mark_watched(epid)  # mark them in calendar
                     self.eps_marked = self.eps_watched  # update list with already marked episodes
                     log('Full sync has been performed.')


### PR DESCRIPTION
- remove check that prevent from parsing pages of shows with simple one word titles
- add some debug logging for the service so we can see when we fail to get an epid
- update version number
